### PR TITLE
Change the default environment to DEVELOPMENT

### DIFF
--- a/config/environment/.env.example.php
+++ b/config/environment/.env.example.php
@@ -9,7 +9,7 @@ use Opulence\Sessions\Handlers\FileSessionHandler;
  * Set environment metadata
  * ----------------------------------------------------------
  */
-$environment->setVar("ENV_NAME", Environment::PRODUCTION);
+$environment->setVar("ENV_NAME", Environment::DEVELOPMENT);
 
 /**
  * ----------------------------------------------------------


### PR DESCRIPTION
When I follow the instructions in [document](https://www.opulencephp.com/docs/1.0/installing) and [Tutorial.fortune.php](https://github.com/opulencephp/Project/blob/1.0/resources/views/Tutorial.fortune.php)  to create a project and change the routes, nothing happened, this was confusing.
