### PR TITLE
Fix image background in the middle/small size view

### DIFF
--- a/public/assets/css/style.css
+++ b/public/assets/css/style.css
@@ -180,7 +180,7 @@ main
 
     #welcome-wrapper
     {
-        padding: 100px 162px;
+        padding: 100px 162px 100px 182px;
         min-width: 800px;
         max-width: 1024px;
         background: url('/assets/images/opulence-background.png') 20px 100px no-repeat;

--- a/public/assets/css/style.css
+++ b/public/assets/css/style.css
@@ -183,7 +183,7 @@ main
         padding: 100px 162px;
         min-width: 800px;
         max-width: 1024px;
-        background: url('/assets/images/opulence-background.png') 0 100px no-repeat;
+        background: url('/assets/images/opulence-background.png') 20px 100px no-repeat;
     }
 }
 


### PR DESCRIPTION
Added 20px because if we see in small size window (example split 1/2 monitor) the image in background stay all in the left (it's very bad to see).

Nothing more.
