### PR TITLE
Fix composer.json scripts

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -38,7 +38,7 @@
     ],
     "post-create-project-cmd": [
       "php apex encryption:generatekey",
-      "php -r \"echo 'Important: make ' . __DIR__ . '/tmp writable\n';\""
+      "php -r \"echo 'Important: make ' . __DIR__ . DIRECTORY_SEPARATOR . 'tmp writable' . PHP_EOL;\""
     ],
     "post-install-cmd": [
       "php -r \"shell_exec((file_exists(getcwd() . '/composer.phar') ? PHP_BINARY . ' composer.phar' : 'composer') . ' dump-autoload -o');\"",


### PR DESCRIPTION
1) Fix `composer.json` `post-create-project-cmd` script to avoid error in console:

```
Script php -r "echo 'Important: make ' . __DIR__ . '/tmp writable
';" handling the post-create-project-cmd event returned with error code 1
```

2) Fix calculated path to take into account OS

For example on Win OS

```
Important: make C:\Users\creocoder\Projects\Acme/tmp writable
```

=>

```
Important: make C:\Users\creocoder\Projects\Acme\tmp writable
```